### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,4 +17,5 @@ into MSBuild project references (ProjectReference) in project files. It will do 
 
 * Run the tool on a solution file: ConvertProjDepToProjRef.exe MySolution.sln
 * Update C++ projects that only perform custom builds as ConfigurationType “Utility”
+* Remove the RuntimeIdentifier element for C# projects that only perform custom builds
 * Use a text editor to remove the ProjectSection(ProjectDependencies) = postProject sections from the .sln file.


### PR DESCRIPTION
Some .csproj files might have RuntimeIdentifier elements inside them. If it's a custom build only, the build works while having solution dependencies, but seems to fail when migrating to project references. For custom build C# projects, I found that removing this element fixes any error.