### PR TITLE
Add .cmd file to publish and code sign the windows x64 executable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,17 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
+
+## [1.0.1 - 2024-11-16]
+
+### Changed
+
+- Updated to .NET 9.0
+
+## [1.0.0 - 2021-9-21]
+
+### Added
+
+- Initial release.

--- a/ConvertProjDepToProjRef.sln
+++ b/ConvertProjDepToProjRef.sln
@@ -8,6 +8,7 @@ EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{29631BE0-1DDD-4846-A61A-E3E8EC9F7C1B}"
 	ProjectSection(SolutionItems) = preProject
 		.editorconfig = .editorconfig
+		CHANGELOG.md = CHANGELOG.md
 		Directory.Build.props = Directory.Build.props
 		Directory.Packages.props = Directory.Packages.props
 		nuget.config = nuget.config

--- a/README.md
+++ b/README.md
@@ -32,3 +32,16 @@ dotnet build -c Release
 * Update C++ projects that only perform custom builds as ConfigurationType “Utility”
 * Remove the RuntimeIdentifier element for C# projects that only perform custom builds
 * Use a text editor to remove the ProjectSection(ProjectDependencies) = postProject sections from the .sln file.
+
+## Prebuild Executable
+
+As convenience a prebuild executable for Windows x64 is available.
+Go to the [releases](https://github.com/vbaderks/ConvertProjDepToProjRef/releases) page and click on
+Assets at the bottom to show the files available in a release.
+Download the binary file ConvertProjDepToProjRef.exe.
+
+> [!NOTE]
+> Microsoft Defender SmartScreen may show a warning about an unrecognised app when running the executable for the first time.
+Click on "More Info" + "Run anyway" to continue.  
+The executable is signed, but Defender SmartScreen requires an Extended Validation (EV) code signing certificate, which is only available
+to commercial organisations, for direct full trust.

--- a/create-signed-release.cmd
+++ b/create-signed-release.cmd
@@ -1,0 +1,2 @@
+dotnet publish -c release
+signtool sign /fd SHA256 /td SHA256 /v /sha1 b834c6c1d7e0ae8e76cadcf9e2e7a273133a5df6 /tr "http://time.certum.pl/" "build\bin\Release\win-x64\publish\ConvertProjDepToProjRef.exe"

--- a/src/ConvertProjDepToProjRef.csproj
+++ b/src/ConvertProjDepToProjRef.csproj
@@ -7,7 +7,8 @@ SPDX-License-Identifier: MIT
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <PackAsTool>true</PackAsTool>
+    <PublishSingleFile>true</PublishSingleFile>
+    <Version>1.0.1</Version>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Change the project to make it possible to publish to a single outputfile. The alternative would be to publish the tool as a NuGet .NET tool. Given the scope of this tool this would add to much overhead.